### PR TITLE
Supports OpenTSDB Telnet-Style API with configuration switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to run the plugin.
 
 
 # Transformations
-## [Parse OpenTSDB transformation](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-transform-opentsdb/transformations/ParseOpenTSDB.html)
+## [Parse OpenTSDB transformation](https://jcustenborder.github.io/kafka-connect-documentation/projects/kafka-connect-opentsdb/transformations/ParseOpenTSDB.html)
 
 *Key*
 ```
@@ -40,7 +40,7 @@ com.github.jcustenborder.kafka.connect.opentsdb.ParseOpenTSDB$Key
 com.github.jcustenborder.kafka.connect.opentsdb.ParseOpenTSDB$Value
 ```
 
-The ParseOpenTSDB transformation will parse data that is formatted with the OpenTSDB wire protocol.
+The ParseOpenTSDB transformation will parse data that is formatted with the OpenTSDB wire protocol or the telnet-style API protocol.
 ### Tip
 
 This transformation expects data to be a String. You are most likely going to use the StringConverter.

--- a/src/main/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDB.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDB.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @DocumentationTip("This transformation expects data to be a String. You are " +
     "most likely going to use the StringConverter.")
 public class ParseOpenTSDB<R extends ConnectRecord<R>> extends BaseKeyValueTransformation<R> {
-  OpenTSDBParser parser = new OpenTSDBParser();
+  OpenTSDBParser parser;
 
   protected ParseOpenTSDB(boolean isKey) {
     super(isKey);
@@ -41,7 +41,7 @@ public class ParseOpenTSDB<R extends ConnectRecord<R>> extends BaseKeyValueTrans
 
   @Override
   public ConfigDef config() {
-    return new ConfigDef();
+    return ParseOpenTSDBConfig.config();
   }
 
   @Override
@@ -50,8 +50,8 @@ public class ParseOpenTSDB<R extends ConnectRecord<R>> extends BaseKeyValueTrans
   }
 
   @Override
-  public void configure(Map<String, ?> configs) {
-
+  public void configure(Map<String, ?> settings) {
+    this.parser = new OpenTSDBParser(new ParseOpenTSDBConfig(settings));
   }
 
   @Override

--- a/src/main/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDBConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDBConfig.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright © 2020 David Chaiken (chaiken@acm.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.opentsdb;
+
+import com.github.jcustenborder.kafka.connect.utils.config.ConfigKeyBuilder;
+import com.github.jcustenborder.kafka.connect.utils.config.ConfigUtils;
+import com.github.jcustenborder.kafka.connect.utils.config.Description;
+import com.github.jcustenborder.kafka.connect.utils.config.recommenders.Recommenders;
+import com.github.jcustenborder.kafka.connect.utils.config.validators.Validators;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+// public ???
+class ParseOpenTSDBConfig extends AbstractConfig {
+
+  public static final String PROTOCOL_TYPE_CONF = "protocol.type";
+  public static final String PROTOCOL_TYPE_DOC = ConfigUtils.enumDescription(ProtocolType.class);
+
+  public enum ProtocolType {
+    @Description("The WireProtocol (default) option is the most standard OpenTSDB format.")
+    WireProtocol,
+    // When this Description is missing, instantiating the ParseOpenTSDBConfig class fails
+    // with a NoClassDefFoundError. That seems like a pretty extreme consequence of a missing
+    // comment.
+    @Description("The TelnetProtocol is the format associated with the put command" +
+                 " of the OpenTSDB Telnet Style API.")
+    TelnetProtocol
+  }
+
+  public final ProtocolType protocolType;
+
+  public ParseOpenTSDBConfig(Map<String, ?> settings) {
+    super(config(), settings);
+    this.protocolType = ConfigUtils.getEnum(ProtocolType.class, this, PROTOCOL_TYPE_CONF);
+  }
+
+  public static ConfigDef config() {
+    return new ConfigDef()
+        .define(
+            ConfigKeyBuilder.of(PROTOCOL_TYPE_CONF, ConfigDef.Type.STRING)
+                .importance(ConfigDef.Importance.HIGH)
+                .documentation(PROTOCOL_TYPE_DOC)
+                .defaultValue(ProtocolType.WireProtocol.toString())
+                .validator(Validators.validEnum(ProtocolType.class))
+                .recommender(Recommenders.enumValues(ProtocolType.class))
+                .build()
+        );
+  }
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDBTelnetTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDBTelnetTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright © 2019 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jcustenborder.kafka.connect.opentsdb;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+public class ParseOpenTSDBTelnetTest {
+
+  ParseOpenTSDB.Value<SinkRecord> transformation;
+
+  @BeforeEach
+  public void before() {
+    this.transformation = new ParseOpenTSDB.Value<>();
+    this.transformation.configure(
+        ImmutableMap.of(ParseOpenTSDBConfig.PROTOCOL_TYPE_CONF,
+			ParseOpenTSDBConfig.ProtocolType.TelnetProtocol.toString())
+    );
+  }
+
+  @TestFactory
+  public Stream<DynamicTest> apply() {
+    Map<String, Struct> testcases = new LinkedHashMap<>();
+    testcases.put(
+        "(ignore me)put  mysql.bytes_received  1287333217 327810227706 schema=foo   host=db1",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_received")
+            .put("timestamp", new Date(1287333217L * 1000L))
+            .put("value", 327810227706D)
+            .put("tags", ImmutableMap.of("schema", "foo", "host", "db1"))
+    );
+    testcases.put("put mysql.bytes_sent 1287333217 6604859181710 schema=foo host=db1",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_sent")
+            .put("timestamp", new Date(1287333217L * 1000L))
+            .put("value", 6604859181710D)
+            .put("tags", ImmutableMap.of("schema", "foo", "host", "db1"))
+    );
+    testcases.put("put mysql.bytes_received 1287333232 -327812421706.2718 schema=foo host=db1",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_received")
+            .put("timestamp", new Date(1287333232L * 1000L))
+            .put("value", -327812421706.2718D)
+            .put("tags", ImmutableMap.of("schema", "foo", "host", "db1"))
+    );
+    testcases.put("!@#$%^&*()-_+=1234567890[]{}\\|put mysql.bytes_sent 1287333232 6604901075387 schema=foo host=db1",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_sent")
+            .put("timestamp", new Date(1287333232L * 1000L))
+            .put("value", 6604901075387D)
+            .put("tags", ImmutableMap.of("schema", "foo", "host", "db1"))
+    );
+    testcases.put("-->puttputtputput mysql.bytes_put 1287333321 340899533915 schema=put host=db2",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_put")
+            .put("timestamp", new Date(1287333321L * 1000L))
+            .put("value", 340899533915D)
+            .put("tags", ImmutableMap.of("schema", "put", "host", "db2"))
+    );
+    testcases.put("put mysql.bytes_sent 1287333321 5506469130707 schema=foo host=db2",
+        new Struct(OpenTSDBParser.SCHEMA)
+            .put("metricName", "mysql.bytes_sent")
+            .put("timestamp", new Date(1287333321L * 1000L))
+            .put("value", 5506469130707D)
+            .put("tags", ImmutableMap.of("schema", "foo", "host", "db2"))
+    );
+
+    return testcases.entrySet().stream()
+        .map(e -> dynamicTest(e.getKey(), () -> {
+          final SinkRecord input = new SinkRecord(
+              "test",
+              1,
+              null,
+              null,
+              Schema.STRING_SCHEMA,
+              e.getKey(),
+              123412L
+          );
+          final SinkRecord output = this.transformation.apply(input);
+          assertNotNull(output);
+          assertTrue(output.value() instanceof Struct, "output.value() should be a struct.");
+          assertStruct(e.getValue(), (Struct) output.value());
+        }));
+  }
+
+}

--- a/src/test/resources/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDB/telnet_example.json
+++ b/src/test/resources/com/github/jcustenborder/kafka/connect/opentsdb/ParseOpenTSDB/telnet_example.json
@@ -1,0 +1,27 @@
+{
+  "title" : "Telnet API Example",
+  "input" : {
+    "topic" : "foo",
+    "kafkaPartition" : 1,
+    "keySchema" : {
+      "type" : "STRING",
+      "isOptional" : false
+    },
+    "key" : "foo",
+    "valueSchema" : {
+      "type" : "STRING",
+      "isOptional" : false
+    },
+    "value" : "<Skip This> put mysql.bytes_received 1287333217 327810227706 schema=foo host=db1",
+    "timestamp" : 1530286549123,
+    "timestampType" : "CREATE_TIME",
+    "offset" : 91283741,
+    "headers" : [ ]
+  },
+  "description" : "This data takes a string value and parses the data based on the OpenTSDB Telnet API protocol.",
+  "name" : "Telnet API Example",
+  "config" : {
+    "protocol.type": "TelnetProtocol"
+  },
+  "childClass" : "Value"
+}


### PR DESCRIPTION
Set transforms.opentsdb.protocol.type = TelnetProtocol to switch from the default wired protocol to the Telnet style API: http://opentsdb.net/docs/build/html/api_telnet/index.html

Also fixes the URL for the documentation in the README.md file.
